### PR TITLE
Issue: https://github.com/aelve/codesearch/issues/59

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -6,6 +6,4 @@ mydb = {
     user = "postgres"
     password = "postgres"
   }
-
-  numThreads = 10
 }


### PR DESCRIPTION
Sets default value eq 20 for `numThreads` property.
Property `maxConnections` = `numThreads` * 5.

Read more here: http://slick.lightbend.com/doc/3.1.0/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef