### PR TITLE
[#noissue] Move scalafmtCheck into a separate CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,11 @@ jobs:
 
       - run:
           command:
-            sbt scalafmtCheck compile exit
+            sbt compile exit
+
+      - run:
+          command:
+            sbt scalafmtCheck exit
 
       - save_cache:
           key: codesearch-{{ checksum "project/Builder.scala" }}-{{ checksum "build.sbt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,9 @@ jobs:
             sbt compile exit
 
       - run:
-          command:
-            sbt scalafmtCheck exit
+          command: |
+            sbt scalafmt exit
+            git diff --exit-code
 
       - save_cache:
           key: codesearch-{{ checksum "project/Builder.scala" }}-{{ checksum "build.sbt" }}


### PR DESCRIPTION
This way we will be able to see whether the CI failure is non-trivial (failing tests, etc), or just a formatting issue. This will make CI more useful once we actually have any tests :trollface: