### PR TITLE
[#noissue] Replace typeclasses boilerplate with simulacrum annotation

### DIFF
--- a/core/src/main/scala/codesearch/core/index/HaskellIndex.scala
+++ b/core/src/main/scala/codesearch/core/index/HaskellIndex.scala
@@ -7,7 +7,7 @@ import codesearch.core.db.HackageDB
 import codesearch.core.index.LanguageIndex.{CSearchResult, CodeSnippet}
 import codesearch.core.index.repository.HackagePackage
 import repository.Extensions._
-import codesearch.core.index.directory.PackageDirectory._
+import codesearch.core.index.directory.Directory._
 
 import sys.process._
 import codesearch.core.model.{HackageTable, Version}

--- a/core/src/main/scala/codesearch/core/index/JavaScriptIndex.scala
+++ b/core/src/main/scala/codesearch/core/index/JavaScriptIndex.scala
@@ -8,7 +8,7 @@ import codesearch.core.db.NpmDB
 import codesearch.core.index.LanguageIndex.{CSearchResult, CodeSnippet}
 import codesearch.core.index.repository.NpmPackage
 import repository.Extensions._
-import codesearch.core.index.directory.PackageDirectory._
+import codesearch.core.index.directory.Directory._
 
 import scala.sys.process._
 import codesearch.core.model.{NpmTable, Version}

--- a/core/src/main/scala/codesearch/core/index/RubyIndex.scala
+++ b/core/src/main/scala/codesearch/core/index/RubyIndex.scala
@@ -10,7 +10,7 @@ import codesearch.core.index.repository.GemPackage
 import codesearch.core.model.{GemTable, Version}
 import codesearch.core.util.Helper
 import repository.Extensions._
-import codesearch.core.index.directory.PackageDirectory._
+import codesearch.core.index.directory.Directory._
 
 import sys.process._
 import org.slf4j.{Logger, LoggerFactory}

--- a/core/src/main/scala/codesearch/core/index/RustIndex.scala
+++ b/core/src/main/scala/codesearch/core/index/RustIndex.scala
@@ -5,7 +5,7 @@ import codesearch.core.db.CratesDB
 import codesearch.core.index.LanguageIndex._
 import codesearch.core.index.repository.CratesPackage
 import repository.Extensions._
-import codesearch.core.index.directory.PackageDirectory._
+import codesearch.core.index.directory.Directory._
 import codesearch.core.model
 import codesearch.core.model.{CratesTable, Version}
 import codesearch.core.util.Helper

--- a/core/src/main/scala/codesearch/core/index/directory/Directory.scala
+++ b/core/src/main/scala/codesearch/core/index/directory/Directory.scala
@@ -4,6 +4,7 @@ import java.nio.file.{Path, Paths}
 
 import codesearch.core.index.directory.PathOps._
 import codesearch.core.index.repository._
+import simulacrum.typeclass
 
 object PathOps {
   implicit final class RichPath(val parent: Path) {
@@ -12,7 +13,7 @@ object PathOps {
   }
 }
 
-private[index] trait Directory[A <: SourcePackage] {
+@typeclass trait Directory[A <: SourcePackage] {
 
   /** Defines root directory for sources storing
     *
@@ -42,12 +43,7 @@ private[index] trait Directory[A <: SourcePackage] {
 }
 
 /** Companion contained defines type-classes for inheritors [[SourcePackage]] */
-object PackageDirectory {
-
-  implicit class PackageDirectoryOps[A <: SourcePackage](val pack: A) {
-    def archive(implicit ev: Directory[A]): Path    = ev.archive(pack)
-    def unarchived(implicit ev: Directory[A]): Path = ev.unarchived(pack)
-  }
+object Directory {
 
   implicit def hackageDirectory: Directory[HackagePackage] = new Directory[HackagePackage] {
     override def archive(pack: HackagePackage): Path =

--- a/core/src/main/scala/codesearch/core/index/repository/Download.scala
+++ b/core/src/main/scala/codesearch/core/index/repository/Download.scala
@@ -2,12 +2,10 @@ package codesearch.core.index.repository
 
 import java.nio.file.Path
 
+import simulacrum.typeclass
+
 import scala.concurrent.Future
 
-trait Download[A <: SourcePackage] {
+@typeclass trait Download[A] {
   def downloadSources(pack: A): Future[Path]
-}
-
-object Download {
-  def apply[A <: SourcePackage](implicit download: Download[A]): Download[A] = download
 }

--- a/core/src/main/scala/codesearch/core/index/repository/Extensions.scala
+++ b/core/src/main/scala/codesearch/core/index/repository/Extensions.scala
@@ -1,29 +1,27 @@
 package codesearch.core.index.repository
 
-trait Extension[A] {
+import simulacrum.typeclass
+
+@typeclass trait Extensions[A] {
   def extensions: Set[String]
 }
 
 object Extensions {
 
-  implicit def jsExtensions[A <: JavaScript]: Extension[A] = new Extension[A] {
+  implicit def jsExtensions[A <: JavaScript]: Extensions[A] = new Extensions[A] {
     override def extensions: Set[String] =
       Set("js", "ts", "json", "xml", "yml", "coffee", "markdown", "md", "yaml", "txt")
   }
 
-  implicit def haskellExtensions[A <: Haskell]: Extension[A] = new Extension[A] {
+  implicit def haskellExtensions[A <: Haskell]: Extensions[A] = new Extensions[A] {
     override def extensions: Set[String] = Set("hs", "lhs", "hsc", "hs-boot", "lhs-boot")
   }
 
-  implicit def rubyExtensions[A <: Ruby]: Extension[A] = new Extension[A] {
+  implicit def rubyExtensions[A <: Ruby]: Extensions[A] = new Extensions[A] {
     override def extensions: Set[String] = Set("rb", "rbx", "irb")
   }
 
-  implicit def rustExtensions[A <: Rust]: Extension[A] = new Extension[A] {
+  implicit def rustExtensions[A <: Rust]: Extensions[A] = new Extensions[A] {
     override def extensions: Set[String] = Set("rs")
-  }
-
-  object Extension {
-    def apply[A <: SourcePackage](implicit ext: Extension[A]): Extension[A] = ext
   }
 }

--- a/core/src/main/scala/codesearch/core/index/repository/SourceRepository.scala
+++ b/core/src/main/scala/codesearch/core/index/repository/SourceRepository.scala
@@ -1,10 +1,10 @@
 package codesearch.core.index.repository
+
 import java.io.File
 import java.nio.file.Path
 
 import codesearch.core.index.directory.Directory
-import codesearch.core.index.directory.PackageDirectory._
-import codesearch.core.index.repository.Extensions.Extension
+import codesearch.core.index.directory.Directory.ops._
 import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
 import com.softwaremill.sttp.{Uri, _}
 import org.apache.commons.io.FileUtils
@@ -26,12 +26,12 @@ object SourceRepository {
       message: String
   ) extends Throwable(message)
 
-  implicit def packageDownloader[A <: SourcePackage: Extension: Directory]: Download[A] =
+  implicit def packageDownloader[A <: SourcePackage: Extensions: Directory]: Download[A] =
     (pack: A) => {
       for {
         archive   <- download(pack.url, pack.archive)
         directory <- pack.extract(archive, pack.unarchived)
-        _         <- deleteExcessFiles(directory, Extension[A].extensions)
+        _         <- deleteExcessFiles(directory, Extensions[A].extensions)
       } yield directory
     }.andThen { case Failure(ex) => logger.error(ex.getMessage) }
 

--- a/project/Builder.scala
+++ b/project/Builder.scala
@@ -30,18 +30,20 @@ object Builder {
     ),
     scalacOptions in (Compile, console) -= "-Ywarn-unused-import",
     scalacOptions in (Compile, doc) ++= Seq("-diagrams", "-implicits"),
-    scalacOptions in Test ++= Seq("-Yrangepos")
+    scalacOptions in Test ++= Seq("-Yrangepos"),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )
 
   lazy val commonDeps = Seq(
     libraryDependencies ++= Seq(
-      "com.github.scopt"  %% "scopt"          % "3.7.0",
-      "com.lihaoyi"       %% "ammonite-ops"   % "1.0.3",
-      "org.rauschig"      % "jarchivelib"     % "0.7.1",
-      "commons-io"        % "commons-io"      % "2.6",
-      "javax.inject"      % "javax.inject"    % "1",
-      "ch.qos.logback"    % "logback-classic" % "1.2.3",
-      "com.typesafe.play" %% "play-json"      % "2.6.9"
+      "com.github.scopt"     %% "scopt"          % "3.7.0",
+      "com.lihaoyi"          %% "ammonite-ops"   % "1.0.3",
+      "org.rauschig"         % "jarchivelib"     % "0.7.1",
+      "commons-io"           % "commons-io"      % "2.6",
+      "javax.inject"         % "javax.inject"    % "1",
+      "ch.qos.logback"       % "logback-classic" % "1.2.3",
+      "com.typesafe.play"    %% "play-json"      % "2.6.9",
+      "com.github.mpilquist" %% "simulacrum"     % "0.13.0"
     )
   )
 


### PR DESCRIPTION
It would be better to use [simulacrum](https://github.com/mpilquist/simulacrum) to reduce typeclasses boilerplate.